### PR TITLE
Added a submit button to the right of the clear button on bot screen

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -125,9 +125,11 @@ with gr.Blocks() as demo:
             with gr.Column():
                 chatbot = gr.Chatbot(bubble_full_width = False)
                 msg = gr.Textbox()
-                clear = gr.ClearButton([msg, chatbot])
                 msg.submit(chatInvoke, [msg, promptInfo, chatbot], [msg, chatbot])
-                #chat_interface = gr.ChatInterface(fn=chat, chatbot=chatbot)
+                with gr.Row():
+                    clear = gr.ClearButton([msg, chatbot])
+                    submit = gr.Button("Submit", variant="primary")
+                    submit.click(chatInvoke, [msg, promptInfo, chatbot], [msg, chatbot])
 
     with gr.Group(visible=False) as questionnairePage3:
         with gr.Tab(englishLabels['lang-1']):


### PR DESCRIPTION
Added a submit button to the right of the clear button on bot screen, to avoid accidental click and clear of chat history when submit functionality might be intended.  Fixes issue #27 